### PR TITLE
Fix parser generation with CLion distribution

### DIFF
--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
@@ -27,7 +27,11 @@ class GenerateParser extends BaseTask {
 
             def requiredLibs = [
                     "jdom", "trove4j", "junit", "guava", "asm-all", "automaton", "platform-api", "platform-impl",
-                    "util", "annotations", "picocontainer", "extensions", "idea", "openapi", "Grammar-Kit"
+                    "util", "annotations", "picocontainer", "extensions", "idea", "openapi", "Grammar-Kit",
+                    // CLion unlike IDEA contains `MockProjectEx` in `testFramework.jar` instead of `idea.jar`
+                    // so this jar should be in `requiredLibs` list to avoid `NoClassDefFoundError` exception
+                    // while parser generation with CLion distribution
+                    "testFramework"
             ]
 
             classpath project.configurations.compileOnly.files.findAll({


### PR DESCRIPTION
Add `testFramework.jar` to classpath to avoid `NoClassDefFoundError` while parser generation with CLion

Fixes #17 