### PR TITLE
Workaround for jitpack.io maven repo returning 522 http status

### DIFF
--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
@@ -11,7 +11,7 @@ class GrammarKit implements Plugin<Project> {
         target.afterEvaluate {
             target.repositories {
                 maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
-                maven { url 'https://jitpack.io' }
+                maven { url 'https://www.jitpack.io' }
             }
             target.dependencies.add(
                     JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,


### PR DESCRIPTION
According to https://github.com/jitpack/jitpack.io/issues/3973