### PR TITLE
Fix NoClassDefFoundError exception while parser generation with 2020.1 platform

### DIFF
--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
@@ -28,7 +28,7 @@ class GenerateParser extends BaseTask {
             def requiredLibs = [
                     "jdom", "trove4j", "junit", "guava", "asm-all", "automaton", "platform-api", "platform-impl",
                     "util", "annotations", "picocontainer", "extensions", "idea", "openapi", "Grammar-Kit",
-                    "platform-util-ui",
+                    "platform-util-ui", "platform-concurrency",
                     // CLion unlike IDEA contains `MockProjectEx` in `testFramework.jar` instead of `idea.jar`
                     // so this jar should be in `requiredLibs` list to avoid `NoClassDefFoundError` exception
                     // while parser generation with CLion distribution


### PR DESCRIPTION
Fixes #24

This change adds `platform-concurrency.jar` into `Grammar-Kit` classpath because `MergeQuery` class (used by `Grammar-Kit`) was moved from `platform-api` module to `platform-concurrency` one.