### PR TITLE
Replace deprecated dependencies configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'groovy'
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    implementation gradleApi()
+    implementation localGroovy()
 }
 
 version = '2020.3.2'


### PR DESCRIPTION
`compile` has been deprecated for some time and will be removed in Gradle 7.0.