### PR TITLE
Use cache-redirector to get proper jetbrains repo location

### DIFF
--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
@@ -10,7 +10,7 @@ class GrammarKit implements Plugin<Project> {
         def grammarKitExtension = target.extensions.create("grammarKit", GrammarKitPluginExtension.class)
         target.afterEvaluate {
             target.repositories {
-                maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
+                maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
                 maven { url 'https://www.jitpack.io' }
             }
             target.dependencies.add(


### PR DESCRIPTION
Otherwise, when bintray is down users get something like 
```
> Failed to notify project evaluation listener.
   > Could not resolve all files for configuration ':compileOnly'.
      > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
        Required by:
            project :
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
   > Could not resolve all files for configuration ':compileOnly'.
      > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
        Required by:
            project :
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
   > Could not resolve all files for configuration ':compileOnly'.
      > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
        Required by:
            project :
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://dl.bintray.com/jetbrains/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
         > Could not resolve org.jetbrains.intellij.deps.jflex:jflex:1.7.0-1.
            > Could not get resource 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'.
               > Could not GET 'https://jetbrains.bintray.com/intellij-third-party-dependencies/org/jetbrains/intellij/deps/jflex/jflex/1.7.0-1/jflex-1.7.0-1.pom'. Received status code 403 from server: Forbidden
```
