### PR TITLE
Provide a specific configuration for the generate tasks pre-configured with the required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ grammarKit {
 
     // tag or short commit hash of Grammar-Kit to use (see link below). Default is 2020.3.1
     grammarKitRelease = '6452fde524'
+  
+    // version of IntelliJ platform dependencies to use, Default is 211.6693.115
+    intellijRelease = '203.7717.81'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ grammarKit {
     // tag or short commit hash of Grammar-Kit to use (see link below). Default is 2020.3.1
     grammarKitRelease = '6452fde524'
   
-    // version of IntelliJ platform dependencies to use, Default is 211.6693.115
+    // optionally provide an IntelliJ version to build the classpath for GenerateParser/GenerateLexer tasks
     intellijRelease = '203.7717.81'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,23 +6,11 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.11.0"
-        classpath "com.vanniktech:gradle-maven-publish-plugin:0.14.2"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
     }
 }
 
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'groovy'
-apply plugin: "com.vanniktech.maven.publish"
-
-publishing {
-    repositories {
-        maven {
-            name = "installLocally"
-            url = "${rootProject.buildDir}/localMaven"
-        }
-    }
-}
 
 dependencies {
     implementation gradleApi()

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,23 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.11.0"
+        classpath "com.vanniktech:gradle-maven-publish-plugin:0.14.2"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
     }
 }
 
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: 'groovy'
+apply plugin: "com.vanniktech.maven.publish"
+
+publishing {
+    repositories {
+        maven {
+            name = "installLocally"
+            url = "${rootProject.buildDir}/localMaven"
+        }
+    }
+}
 
 dependencies {
     implementation gradleApi()

--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
@@ -8,51 +8,74 @@ class GrammarKit implements Plugin<Project> {
     @Override
     void apply(Project target) {
         def grammarKitExtension = target.extensions.create("grammarKit", GrammarKitPluginExtension.class)
-        target.configurations {
-          grammarKitClassPath
-        }
         target.afterEvaluate {
             target.repositories {
                 maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
                 maven { url "https://www.jetbrains.com/intellij-repository/releases" }
                 maven { url 'https://www.jitpack.io' }
             }
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "com.github.JetBrains:Grammar-Kit:${grammarKitExtension.grammarKitRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "org.jetbrains.intellij.deps.jflex:jflex:${grammarKitExtension.jflexRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "com.jetbrains.intellij.platform:indexing-impl:${grammarKitExtension.intellijRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "com.jetbrains.intellij.platform:analysis-impl:${grammarKitExtension.intellijRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "com.jetbrains.intellij.platform:core-impl:${grammarKitExtension.intellijRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "com.jetbrains.intellij.platform:lang-impl:${grammarKitExtension.intellijRelease}"
-            )
-            target.dependencies.add(
-                    target.configurations.grammarKitClassPath.name,
-                    "org.jetbrains.intellij.deps:asm-all:7.0.1"
-            )
-            target.configurations.grammarKitClassPath {
-              exclude group: 'com.jetbrains.rd'
-              exclude group: 'org.jetbrains.marketplace'
-              exclude group: 'org.roaringbitmap'
-              exclude group: 'org.jetbrains.plugins'
-              exclude module: 'idea'
-              exclude module: 'ant'
+            if (grammarKitExtension.intellijRelease == null) {
+                target.dependencies.add(
+                        JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
+                        "com.github.JetBrains:Grammar-Kit:${grammarKitExtension.grammarKitRelease}",
+                        {
+                            exclude group: 'org.jetbrains.plugins'
+                            exclude module: 'idea'
+                        })
+                target.dependencies.add(
+                        JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
+                        "org.jetbrains.intellij.deps.jflex:jflex:${grammarKitExtension.jflexRelease}",
+                        {
+                            exclude group: 'org.jetbrains.plugins'
+                            exclude module: 'idea'
+                            exclude module: 'ant'
+                        }
+                )
+            } else {
+                configureGrammarKitClassPath()
             }
+        }
+    }
+
+    void configureGrammarKitClassPath(Project target) {
+        target.configurations {
+            grammarKitClassPath
+        }
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "com.github.JetBrains:Grammar-Kit:${grammarKitExtension.grammarKitRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "org.jetbrains.intellij.deps.jflex:jflex:${grammarKitExtension.jflexRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "com.jetbrains.intellij.platform:indexing-impl:${grammarKitExtension.intellijRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "com.jetbrains.intellij.platform:analysis-impl:${grammarKitExtension.intellijRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "com.jetbrains.intellij.platform:core-impl:${grammarKitExtension.intellijRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "com.jetbrains.intellij.platform:lang-impl:${grammarKitExtension.intellijRelease}"
+        )
+        target.dependencies.add(
+                target.configurations.grammarKitClassPath.name,
+                "org.jetbrains.intellij.deps:asm-all:7.0.1"
+        )
+        target.configurations.grammarKitClassPath {
+            exclude group: 'com.jetbrains.rd'
+            exclude group: 'org.jetbrains.marketplace'
+            exclude group: 'org.roaringbitmap'
+            exclude group: 'org.jetbrains.plugins'
+            exclude module: 'idea'
+            exclude module: 'ant'
         }
     }
 }

--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKit.groovy
@@ -8,27 +8,51 @@ class GrammarKit implements Plugin<Project> {
     @Override
     void apply(Project target) {
         def grammarKitExtension = target.extensions.create("grammarKit", GrammarKitPluginExtension.class)
+        target.configurations {
+          grammarKitClassPath
+        }
         target.afterEvaluate {
             target.repositories {
                 maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
+                maven { url "https://www.jetbrains.com/intellij-repository/releases" }
                 maven { url 'https://www.jitpack.io' }
             }
             target.dependencies.add(
-                    JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
-                    "com.github.JetBrains:Grammar-Kit:${grammarKitExtension.grammarKitRelease}",
-                    {
-                        exclude group: 'org.jetbrains.plugins'
-                        exclude module: 'idea'
-                    })
-            target.dependencies.add(
-                    JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
-                    "org.jetbrains.intellij.deps.jflex:jflex:${grammarKitExtension.jflexRelease}",
-                    {
-                        exclude group: 'org.jetbrains.plugins'
-                        exclude module: 'idea'
-                        exclude module: 'ant'
-                    }
+                    target.configurations.grammarKitClassPath.name,
+                    "com.github.JetBrains:Grammar-Kit:${grammarKitExtension.grammarKitRelease}"
             )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "org.jetbrains.intellij.deps.jflex:jflex:${grammarKitExtension.jflexRelease}"
+            )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "com.jetbrains.intellij.platform:indexing-impl:${grammarKitExtension.intellijRelease}"
+            )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "com.jetbrains.intellij.platform:analysis-impl:${grammarKitExtension.intellijRelease}"
+            )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "com.jetbrains.intellij.platform:core-impl:${grammarKitExtension.intellijRelease}"
+            )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "com.jetbrains.intellij.platform:lang-impl:${grammarKitExtension.intellijRelease}"
+            )
+            target.dependencies.add(
+                    target.configurations.grammarKitClassPath.name,
+                    "org.jetbrains.intellij.deps:asm-all:7.0.1"
+            )
+            target.configurations.grammarKitClassPath {
+              exclude group: 'com.jetbrains.rd'
+              exclude group: 'org.jetbrains.marketplace'
+              exclude group: 'org.roaringbitmap'
+              exclude group: 'org.jetbrains.plugins'
+              exclude module: 'idea'
+              exclude module: 'ant'
+            }
         }
     }
 }

--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKitPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKitPluginExtension.groovy
@@ -3,6 +3,6 @@ package org.jetbrains.grammarkit
 class GrammarKitPluginExtension {
     def grammarKitRelease = '2020.3.1'
     def jflexRelease = '1.7.0-1'
-    def intellijRelease = '211.6693.115'
+    String intellijRelease = null
 }
 

--- a/src/main/groovy/org/jetbrains/grammarkit/GrammarKitPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/GrammarKitPluginExtension.groovy
@@ -3,5 +3,6 @@ package org.jetbrains.grammarkit
 class GrammarKitPluginExtension {
     def grammarKitRelease = '2020.3.1'
     def jflexRelease = '1.7.0-1'
+    def intellijRelease = '211.6693.115'
 }
 

--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
@@ -35,7 +35,12 @@ class GenerateLexer extends BaseTask {
             newArgs.add(flexFile)
             args(newArgs)
 
-            classpath project.configurations.grammarKitClassPath.files.findAll({ it.name.startsWith("jflex") })
+            if (project.configurations.hasProperty("grammarKitClassPath")) {
+                classpath project.configurations.grammarKitClassPath
+            } else {
+                classpath project.configurations.compileClasspath.files.findAll(
+                        { it.name.startsWith("jflex") })
+            }
 
             purgeFiles(targetFile)
         })

--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateLexer.groovy
@@ -35,7 +35,7 @@ class GenerateLexer extends BaseTask {
             newArgs.add(flexFile)
             args(newArgs)
 
-            classpath project.configurations.compileClasspath.files.findAll({ it.name.startsWith("jflex") })
+            classpath project.configurations.grammarKitClassPath.files.findAll({ it.name.startsWith("jflex") })
 
             purgeFiles(targetFile)
         })

--- a/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
+++ b/src/main/groovy/org/jetbrains/grammarkit/tasks/GenerateParser.groovy
@@ -25,24 +25,7 @@ class GenerateParser extends BaseTask {
 
             args = [project.file(targetRoot), bnfFile]
 
-            def requiredLibs = [
-                    "jdom", "trove4j", "junit", "guava", "asm-all", "automaton", "platform-api", "platform-impl",
-                    "util", "annotations", "picocontainer", "extensions", "idea", "openapi", "Grammar-Kit",
-                    "platform-util-ui", "platform-concurrency", "intellij-deps-fastutil",
-                    // CLion unlike IDEA contains `MockProjectEx` in `testFramework.jar` instead of `idea.jar`
-                    // so this jar should be in `requiredLibs` list to avoid `NoClassDefFoundError` exception
-                    // while parser generation with CLion distribution
-                    "testFramework"
-            ]
-
-            classpath project.configurations.compileClasspath.files.findAll({
-                for (lib in requiredLibs) {
-                    if (it.name.equalsIgnoreCase("${lib}.jar") || it.name.startsWith("${lib}-")) {
-                        return true;
-                    }
-                }
-                return false;
-            })
+            classpath project.configurations.grammarKitClassPath
 
             purgeFiles(parserFile, psiDir)
         }


### PR DESCRIPTION
Closes #36 

Verified with my project here: https://github.com/AlecStrong/sql-psi/compare/astrong/2021-04-20/grammar-kit-classpath

I opted to provide an override for the external dependency versioning to enable users to provide their own version (similar to grammarkit) but if you would prefer I manually look for jars on the compile classpath I can also do that. Regardless this should hopefully mean downstream users don't have to do any configuration of their classpath to get the tasks working