### PR TITLE
Remove debugging print from GenerateParserTask

### DIFF
--- a/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
@@ -73,7 +73,6 @@ open class GenerateParserTask @Inject constructor(
     fun generateParser() {
         ByteArrayOutputStream().use { os ->
             try {
-                println("classpath='${classpath.files}'")
                 execOperations.javaexec {
                     mainClass.set("org.intellij.grammar.Main")
                     args = getArguments()


### PR DESCRIPTION
I assume this was added to test in [this change](https://github.com/JetBrains/gradle-grammar-kit-plugin/commit/ccfe393112e9c4d0521391373aa9ee69c7b2fbb2), if it is intended to be logged it should use the gradle logger so it only appears at an info/debug level