### PR TITLE
Update the plugin usage documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ grammarKit {
   jflexRelease = "1.7.0-1"
 
   // Release version, tag, or short commit hash of Grammar-Kit to use (see link below). By default, the latest available is used.
-  grammarKitRelease = "2021.1.1"
+  grammarKitRelease = "2021.1.2"
   
   // Optionally provide an IntelliJ version to build the classpath for GenerateParser/GenerateLexer tasks
   intellijRelease = "203.7717.81"
@@ -84,7 +84,7 @@ generateLexer {
     targetClass = "PerlLexer"
     
     // optional, path to the task-specific skeleton file. Default: none
-    skeleton = "/some/specific/skeleton"
+    skeleton = new File("/some/specific/skeleton")
     
     // if set, plugin will remove a lexer output file before generating new one. Default: false
     purgeOldFiles = true
@@ -104,7 +104,7 @@ generateLexer {
     targetClass.set("PerlLexer")
     
     // optional, path to the task-specific skeleton file. Default: none
-    skeleton.set("/some/specific/skeleton")
+    skeleton.set(File("/some/specific/skeleton"))
     
     // if set, plugin will remove a lexer output file before generating new one. Default: false
     purgeOldFiles.set(true)


### PR DESCRIPTION
This PR updates the documentation as `GenerateLexerTask` requires `skeleton` to be a `File`, and not a `String`. 

https://github.com/JetBrains/gradle-grammar-kit-plugin/blob/003a062ecb79c24a0bda1603152696b6acf43d2d/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateLexerTask.kt#L57-L59

When a plain string is provided, the build fails with 
```
> Cannot set the value of task ':generateLexer' property 'skeleton' of type org.gradle.api.file.RegularFile using an instance of type java.lang.String.
```