### PR TITLE
Refactor lexer and parser tasks into javaexec tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Set minimum supported Gradle version from `6.7.1` to `6.8`
+- Make GenerateParserTask and GenerateLexerTask descendants of JavaExec
 
 ## [2021.2.2]
 - Remove redundant `bomConfiguration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 - Set minimum supported Gradle version from `6.7.1` to `6.8`
-- Make GenerateParserTask and GenerateLexerTask descendants of JavaExec
+- Make `GenerateParserTask` and `GenerateLexerTask` subclasses of `JavaExec`
 
 ## [2021.2.2]
 - Remove redundant `bomConfiguration`

--- a/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
@@ -46,7 +46,7 @@ open class GrammarKitPlugin : Plugin<Project> {
             sourceFile.convention(source.map {
                 project.layout.projectDirectory.file(it)
             })
-            jFlexClasspath.setFrom(project.provider {
+            classpath(project.provider {
                 getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
                     file.name.startsWith("jflex")
                 }
@@ -88,7 +88,7 @@ open class GrammarKitPlugin : Plugin<Project> {
                 "testFramework", "3rd-party",
             )
 
-            grammarKitClasspath.setFrom(project.provider {
+            classpath(project.provider {
                 getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
                     requiredLibs.any {
                         file.name.equals("$it.jar", true) || file.name.startsWith("$it-", true)

--- a/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
@@ -46,7 +46,7 @@ open class GrammarKitPlugin : Plugin<Project> {
             sourceFile.convention(source.map {
                 project.layout.projectDirectory.file(it)
             })
-            classpath.setFrom(project.provider {
+            jFlexClasspath.setFrom(project.provider {
                 getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
                     file.name.startsWith("jflex")
                 }
@@ -88,7 +88,7 @@ open class GrammarKitPlugin : Plugin<Project> {
                 "testFramework", "3rd-party",
             )
 
-            classpath.setFrom(project.provider {
+            grammarKitClasspath.setFrom(project.provider {
                 getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
                     requiredLibs.any {
                         file.name.equals("$it.jar", true) || file.name.startsWith("$it-", true)

--- a/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateLexerTask.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateLexerTask.kt
@@ -6,6 +6,7 @@ import org.apache.tools.ant.util.TeeOutputStream
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -77,19 +78,11 @@ abstract class GenerateLexerTask : JavaExec() {
     @get:Optional
     abstract val purgeOldFiles: Property<Boolean>
 
-    /**
-     * The classpath with JFlex to use for the generation.
-     */
-    @get:InputFiles
-    @get:Classpath
-    abstract val jFlexClasspath: ConfigurableFileCollection
-
     @TaskAction
     override fun exec() {
         ByteArrayOutputStream().use { os ->
             try {
                 args = getArguments()
-                classpath = this@GenerateLexerTask.jFlexClasspath
                 errorOutput = TeeOutputStream(System.out, os)
                 standardOutput = TeeOutputStream(System.out, os)
                 super.exec()

--- a/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
@@ -3,17 +3,15 @@
 package org.jetbrains.grammarkit.tasks
 
 import org.apache.tools.ant.util.TeeOutputStream
-import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
-import org.gradle.process.ExecOperations
 import org.jetbrains.grammarkit.path
 import java.io.ByteArrayOutputStream
-import javax.inject.Inject
 
 /**
  * The `generateParser` task generates a parser for the given grammar.
@@ -80,19 +78,11 @@ abstract class GenerateParserTask : JavaExec() {
     @get:Optional
     abstract val purgeOldFiles: Property<Boolean>
 
-    /**
-     * The classpath with Grammar-Kit to use for the generation.
-     */
-    @get:InputFiles
-    @get:Classpath
-    abstract val grammarKitClasspath: ConfigurableFileCollection
-
     @TaskAction
     override fun exec() {
         ByteArrayOutputStream().use { os ->
             try {
                 args = getArguments()
-                classpath = this.grammarKitClasspath
                 errorOutput = TeeOutputStream(System.out, os)
                 standardOutput = TeeOutputStream(System.out, os)
                 super.exec()


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Lexer and parser tasks right now inherit form JavaExec which allows to choose Java version that it runs with.

## Related Issue

#97 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allow user change the Java version used to run tasks, thus fixing potential compatibilty issue.

## How Has This Been Tested

Tested locally with [git-machete-plugin](https://github.com/VirtusLab/git-machete-intellij-plugin), where the problem was first located. This change fixes the problem descirbed in issue #97, but new IntelliJ EAP still can't be run in git-machete project due to a different problem.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
