### PR TITLE
Support Centralized Repository Declaration

### DIFF
--- a/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
@@ -5,16 +5,17 @@ package org.jetbrains.grammarkit
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.initialization.resolve.RepositoriesMode
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.PluginInstantiationException
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.maven
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.grammarkit.GrammarKitConstants.MINIMAL_SUPPORTED_GRADLE_VERSION
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import java.io.File
-import java.net.URI
 
 @Suppress("unused")
 open class GrammarKitPlugin : Plugin<Project> {
@@ -106,12 +107,10 @@ open class GrammarKitPlugin : Plugin<Project> {
             }
         }
 
-        project.repositories.apply {
-            maven {
-                url = URI("https://cache-redirector.jetbrains.com/intellij-dependencies")
-            }
-            maven {
-                url = URI("https://cache-redirector.jetbrains.com/intellij-repository/releases")
+        if (project.settings.dependencyResolutionManagement.repositoriesMode.get() != RepositoriesMode.FAIL_ON_PROJECT_REPOS) {
+            project.repositories.apply {
+                maven(url = "https://cache-redirector.jetbrains.com/intellij-dependencies")
+                maven(url = "https://cache-redirector.jetbrains.com/intellij-repository/releases")
             }
         }
 

--- a/src/main/kotlin/org/jetbrains/grammarkit/utils.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/utils.kt
@@ -14,4 +14,4 @@ val <T : FileSystemLocation> Provider<T>.path: String
     get() = get().asFile.canonicalPath
 
 // https://github.com/gradle/gradle/issues/17295#issuecomment-1053620508
-val Project.settings: Settings get() = (gradle as GradleInternal).settings
+internal val Project.settings: Settings get() = (gradle as GradleInternal).settings

--- a/src/main/kotlin/org/jetbrains/grammarkit/utils.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/utils.kt
@@ -4,8 +4,14 @@
 
 package org.jetbrains.grammarkit
 
+import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 
 val <T : FileSystemLocation> Provider<T>.path: String
     get() = get().asFile.canonicalPath
+
+// https://github.com/gradle/gradle/issues/17295#issuecomment-1053620508
+val Project.settings: Settings get() = (gradle as GradleInternal).settings

--- a/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginSpec.kt
+++ b/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginSpec.kt
@@ -17,4 +17,38 @@ class GrammarKitPluginSpec : GrammarKitPluginBase() {
             tasks(GrammarKitConstants.GROUP_NAME),
         )
     }
+
+    @Test
+    fun `support centralized repository declaration`() {
+        file("settings.gradle").groovy("""
+            dependencyResolutionManagement {
+                repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+            
+                repositories {
+                    mavenCentral()
+                }
+            }
+            
+            rootProject.name = 'projectName'
+        """.trimIndent())
+        buildFile.writeText(
+            buildFile.readText().replace(
+                """
+                repositories {
+                    mavenCentral()
+                }
+                """.trimIndent(),
+                ""
+            )
+        )
+
+        assertEquals(
+            listOf(
+                GrammarKitConstants.GENERATE_LEXER_TASK_NAME,
+                GrammarKitConstants.GENERATE_PARSER_TASK_NAME,
+            ),
+            tasks(GrammarKitConstants.GROUP_NAME),
+        )
+    }
+
 }


### PR DESCRIPTION
# Pull Request Details

## Description

Add a check if `FAIL_ON_PROJECT_REPOS` is set to conditionally add the repositories.

## Related Issue

Fixes #106

## Motivation and Context

Gradle adds incubating support to declare your repositories in your settings gradle file to secure your dependencies supply chain by only downloading dependencies from the declared repositories.

https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration

```kotlin
// settings.gradle.kts
dependencyResolutionManagement {
    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

    repositories {
        mavenCentral()
        maven(url = "https://www.jetbrains.com/intellij-repository/releases")
        maven(url = "https://cache-redirector.jetbrains.com/intellij-dependencies")
        maven(url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies/")
        maven(url = "https://maven.pkg.jetbrains.space/public/p/ktor/eap")
    }
}
```

## How Has This Been Tested

Added a test with `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
