### PR TITLE
Fix getting java configurations by using withPlugin

### DIFF
--- a/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/GrammarKitPlugin.kt
@@ -2,97 +2,96 @@
 
 package org.jetbrains.grammarkit
 
-import org.gradle.api.NamedDomainObjectProvider
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ModuleDependency
-import org.gradle.api.initialization.resolve.RepositoriesMode
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.PluginInstantiationException
-import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.maven
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
-import org.gradle.util.GradleVersion
+import org.gradle.api.*
+import org.gradle.api.artifacts.*
+import org.gradle.api.initialization.resolve.*
+import org.gradle.api.plugins.*
+import org.gradle.api.provider.*
+import org.gradle.kotlin.dsl.*
+import org.gradle.util.*
 import org.jetbrains.grammarkit.GrammarKitConstants.MINIMAL_SUPPORTED_GRADLE_VERSION
-import org.jetbrains.grammarkit.tasks.GenerateLexerTask
-import org.jetbrains.grammarkit.tasks.GenerateParserTask
-import java.io.File
+import org.jetbrains.grammarkit.tasks.*
+import java.io.*
 
 @Suppress("unused")
 open class GrammarKitPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         checkGradleVersion()
+        project.plugins.withId("java") {
+            val extension = project.extensions.create<GrammarKitPluginExtension>(GrammarKitConstants.GROUP_NAME)
 
-        val extension = project.extensions.create<GrammarKitPluginExtension>(GrammarKitConstants.GROUP_NAME)
+            val grammarKitClassPathConfiguration =
+                project.configurations.register(GrammarKitConstants.GRAMMAR_KIT_CLASS_PATH_CONFIGURATION_NAME)
+            val compileClasspathConfiguration =
+                project.configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+            val compileOnlyConfiguration = project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
 
-        val grammarKitClassPathConfiguration =
-            project.configurations.register(GrammarKitConstants.GRAMMAR_KIT_CLASS_PATH_CONFIGURATION_NAME)
-        val compileClasspathConfiguration =
-            project.configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-        val compileOnlyConfiguration = project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
+            project.tasks.register<GenerateLexerTask>(GrammarKitConstants.GENERATE_LEXER_TASK_NAME)
 
-        project.tasks.register<GenerateLexerTask>(GrammarKitConstants.GENERATE_LEXER_TASK_NAME)
+            project.tasks.withType<GenerateLexerTask>().configureEach {
+                classpath(
+                    getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
+                        file.name.startsWith("jflex")
+                    }
+                )
+            }
 
-        project.tasks.withType<GenerateLexerTask>().configureEach {
-            classpath(
-                getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
-                    file.name.startsWith("jflex")
+            project.tasks.register<GenerateParserTask>(GrammarKitConstants.GENERATE_PARSER_TASK_NAME)
+
+            project.tasks.withType<GenerateParserTask>().configureEach {
+                val requiredLibs = listOf(
+                    "app", "jdom", "trove4j", "junit", "guava", "asm-all", "automaton", "platform-api", "platform-impl",
+                    "util", "util_rt", "annotations", "picocontainer", "extensions", "idea", "openapi", "grammar-kit",
+                    "platform-util-ui", "platform-concurrency", "intellij-deps-fastutil",
+                    // CLion unlike IDEA contains `MockProjectEx` in `testFramework.jar` instead of `idea.jar`
+                    // so this jar should be in `requiredLibs` list to avoid `NoClassDefFoundError` exception
+                    // while parser generation with CLion distribution
+                    "testFramework", "3rd-party",
+                )
+
+                classpath(
+                    getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
+                        requiredLibs.any {
+                            file.name.equals("$it.jar", true) || file.name.startsWith("$it-", true)
+                        }
+                    }
+                )
+            }
+
+            if (project.settings.dependencyResolutionManagement.repositoriesMode.get() != RepositoriesMode.FAIL_ON_PROJECT_REPOS) {
+                project.repositories.apply {
+                    maven(url = "https://cache-redirector.jetbrains.com/intellij-dependencies")
+                    maven(url = "https://cache-redirector.jetbrains.com/intellij-repository/releases")
                 }
-            )
-        }
+            }
 
-        project.tasks.register<GenerateParserTask>(GrammarKitConstants.GENERATE_PARSER_TASK_NAME)
+            val grammarKitRelease = extension.grammarKitRelease
+            val jflexRelease = extension.jflexRelease
+            val intellijRelease = extension.intellijRelease
 
-        project.tasks.withType<GenerateParserTask>().configureEach {
-            val requiredLibs = listOf(
-                "app", "jdom", "trove4j", "junit", "guava", "asm-all", "automaton", "platform-api", "platform-impl",
-                "util", "util_rt", "annotations", "picocontainer", "extensions", "idea", "openapi", "grammar-kit",
-                "platform-util-ui", "platform-concurrency", "intellij-deps-fastutil",
-                // CLion unlike IDEA contains `MockProjectEx` in `testFramework.jar` instead of `idea.jar`
-                // so this jar should be in `requiredLibs` list to avoid `NoClassDefFoundError` exception
-                // while parser generation with CLion distribution
-                "testFramework", "3rd-party",
-            )
-
-            classpath(
-                getClasspath(grammarKitClassPathConfiguration, compileClasspathConfiguration) { file ->
-                    requiredLibs.any {
-                        file.name.equals("$it.jar", true) || file.name.startsWith("$it-", true)
+            compileOnlyConfiguration.configure {
+                val grammarJFlexDeps = grammarKitRelease.zip(jflexRelease) { grammarKitRelease, jflexRelease ->
+                    listOf(
+                        "org.jetbrains:grammar-kit:$grammarKitRelease",
+                        "org.jetbrains.intellij.deps.jflex:jflex:$jflexRelease",
+                    ).map(project.dependencies::create).map {
+                        it as ModuleDependency
+                        it.exclude(mapOf("group" to "org.jetbrains.plugins", "module" to "ant"))
+                        it.exclude(mapOf("group" to "org.jetbrains.plugins", "module" to "idea"))
                     }
                 }
+
+                dependencies.addAllLater(intellijRelease.zip(grammarJFlexDeps) { _, deps -> deps })
+            }
+            configureGrammarKitClassPath(
+                project,
+                grammarKitClassPathConfiguration,
+                grammarKitRelease,
+                jflexRelease,
+                intellijRelease
             )
         }
-
-        if (project.settings.dependencyResolutionManagement.repositoriesMode.get() != RepositoriesMode.FAIL_ON_PROJECT_REPOS) {
-            project.repositories.apply {
-                maven(url = "https://cache-redirector.jetbrains.com/intellij-dependencies")
-                maven(url = "https://cache-redirector.jetbrains.com/intellij-repository/releases")
-            }
-        }
-
-        val grammarKitRelease = extension.grammarKitRelease
-        val jflexRelease = extension.jflexRelease
-        val intellijRelease = extension.intellijRelease
-
-        compileOnlyConfiguration.configure {
-            val grammarJFlexDeps = grammarKitRelease.zip(jflexRelease) { grammarKitRelease, jflexRelease ->
-                listOf(
-                    "org.jetbrains:grammar-kit:$grammarKitRelease",
-                    "org.jetbrains.intellij.deps.jflex:jflex:$jflexRelease",
-                ).map(project.dependencies::create).map {
-                    it as ModuleDependency
-                    it.exclude(mapOf("group" to "org.jetbrains.plugins", "module" to "ant"))
-                    it.exclude(mapOf("group" to "org.jetbrains.plugins", "module" to "idea"))
-                }
-            }
-
-            dependencies.addAllLater(intellijRelease.zip(grammarJFlexDeps) { _, deps -> deps })
-        }
-        configureGrammarKitClassPath(project, grammarKitClassPathConfiguration, grammarKitRelease, jflexRelease, intellijRelease)
     }
 
     private fun configureGrammarKitClassPath(
@@ -103,7 +102,12 @@ open class GrammarKitPlugin : Plugin<Project> {
         intellijRelease: Provider<String>,
     ) {
         grammarKitClassPathConfiguration.configure {
-            val deps = intellijRelease.zip(grammarKitRelease.zip(jflexRelease, ::Pair)) { intellijRelease, (grammarKitRelease, jflexRelease) ->
+            val deps = intellijRelease.zip(
+                grammarKitRelease.zip(
+                    jflexRelease,
+                    ::Pair
+                )
+            ) { intellijRelease, (grammarKitRelease, jflexRelease) ->
                 listOf(
                     "org.jetbrains:grammar-kit:$grammarKitRelease",
                     "org.jetbrains.intellij.deps.jflex:jflex:$jflexRelease",

--- a/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginBase.kt
+++ b/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginBase.kt
@@ -36,8 +36,8 @@ abstract class GrammarKitPluginBase {
 
         buildFile.groovy("""
             plugins {
-                id "java"
                 id "org.jetbrains.grammarkit"
+                id "java"
             }
             sourceCompatibility = 1.8
             targetCompatibility = 1.8


### PR DESCRIPTION
# Pull Request Details

I replaced `maybeCreate` with `named` but this only works if the configuration is available (the java plugin is applied). Theoretically, you could apply the grammar-kit-plugin before `java` so this will fail.

## Description
Moved everything into `withPlugin("java")`
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Don't know why the diff looks so bad at GitHub.