### PR TITLE
Gradle best practice: Support build-cache, support java src and remov…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,15 +8,10 @@ fun properties(key: String) = project.findProperty(key)?.toString()
 plugins {
     `kotlin-dsl`
     `maven-publish`
-    kotlin("jvm") version "1.8.10"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("org.jetbrains.changelog") version "2.0.0"
     id("org.jetbrains.dokka") version "1.7.20"
 }
-
-version = properties("version")!!
-group = properties("group")!!
-description = properties("description")
 
 repositories {
     mavenCentral()
@@ -24,7 +19,6 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
-    testImplementation(kotlin("test-junit"))
 }
 
 kotlin {
@@ -44,14 +38,14 @@ gradlePlugin {
     }
 }
 
-val dokkaHtml by tasks.getting(DokkaTask::class)
+val dokkaHtml by tasks.existing(DokkaTask::class)
 val javadocJar by tasks.registering(Jar::class) {
     dependsOn(dokkaHtml)
     archiveClassifier.set("javadoc")
-    from(dokkaHtml.outputDirectory)
+    from(dokkaHtml.map { it.outputDirectory })
 }
 
-val sourcesJar = tasks.register<Jar>("sourcesJar") {
+val sourcesJar by tasks.registering(Jar::class) {
     archiveClassifier.set("sources")
     from(sourceSets.main.get().allSource)
 }
@@ -82,9 +76,6 @@ changelog {
 tasks {
     test {
         val testGradleHomePath = "$buildDir/testGradleHome"
-        doFirst {
-            File(testGradleHomePath).mkdir()
-        }
         systemProperties["test.gradle.home"] = testGradleHomePath
         systemProperties["test.gradle.default"] = properties("gradleVersion")
         systemProperties["test.gradle.version"] = properties("testGradleVersion")

--- a/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
+++ b/src/main/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTask.kt
@@ -28,12 +28,11 @@ abstract class GenerateParserTask : JavaExec() {
     }
 
     @Deprecated(
-        message = "The `source` removed in favour of `sourceFile`",
+        message = "The `source` was removed in favour of `sourceFile`.",
         replaceWith = ReplaceWith("sourceFile"),
         level = DeprecationLevel.ERROR,
     )
-    @get:Input
-    @get:Optional
+    @get:Internal
     abstract val source: Property<String>
 
     /**
@@ -47,19 +46,24 @@ abstract class GenerateParserTask : JavaExec() {
     /**
      * The path to the target directory for the generated parser.
      */
+    @Deprecated(
+        message = "The `targetRoot` was removed in favour of `targetRootOutputDir`.",
+        replaceWith = ReplaceWith("targetRootOutputDir"),
+        level = DeprecationLevel.ERROR,
+    )
     @get:Internal
     abstract val targetRoot: Property<String>
 
     /**
      * Required.
-     * The output root directory computed from the [targetRoot] property.
+     * The output root directory.
      */
     @get:OutputDirectory
     abstract val targetRootOutputDir: DirectoryProperty
 
     /**
      * Required.
-     * The location of the generated parser class, relative to the [targetRoot].
+     * The location of the generated parser class, relative to the [targetRootOutputDir].
      */
     @get:Input
     abstract val pathToParser: Property<String>
@@ -74,18 +78,12 @@ abstract class GenerateParserTask : JavaExec() {
     /**
      * The output parser file computed from the [pathToParser] property.
      */
-    @OutputFile
-    val parserFile: Provider<RegularFile> = pathToParser.zip(targetRoot) { it, targetRoot ->
-        project.layout.projectDirectory.file("$targetRoot/$it")
-    }
+    fun parserFile(): Provider<RegularFile> = targetRootOutputDir.file(pathToParser)
 
     /**
      * The output PSI directory computed from the [pathToPsiRoot] property.
      */
-    @OutputDirectory
-    val psiDir: Provider<Directory> = pathToPsiRoot.zip(targetRoot) { it, targetRoot ->
-        project.layout.projectDirectory.dir("$targetRoot/$it")
-    }
+    fun psiDir(): Provider<Directory> = targetRootOutputDir.dir(pathToPsiRoot)
 
     /**
      * Purge old files from the target directory before generating the lexer.
@@ -93,12 +91,6 @@ abstract class GenerateParserTask : JavaExec() {
     @get:Input
     @get:Optional
     abstract val purgeOldFiles: Property<Boolean>
-
-    init {
-        targetRootOutputDir.convention(targetRoot.map {
-            project.layout.projectDirectory.dir(it)
-        })
-    }
 
     @TaskAction
     override fun exec() {

--- a/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginBase.kt
+++ b/src/test/kotlin/org/jetbrains/grammarkit/GrammarKitPluginBase.kt
@@ -79,7 +79,7 @@ abstract class GrammarKitPluginBase {
             .withTestKitDir(File(gradleHome))
             .withArguments("--configuration-cache", "--stacktrace", *tasks, *gradleArguments)
 
-    fun tasks(groupName: String) = build(ProjectInternal.TASKS_TASK, "--no-configuration-cache").output.lines().run {
+    fun tasks(groupName: String) = build(ProjectInternal.TASKS_TASK).output.lines().run {
         val start = indexOfFirst { it.equals("$groupName tasks", ignoreCase = true) } + 2
         drop(start).takeWhile(String::isNotEmpty).map { it.substringBefore(' ') }
     }

--- a/src/test/kotlin/org/jetbrains/grammarkit/tasks/GenerateLexerTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/grammarkit/tasks/GenerateLexerTaskSpec.kt
@@ -2,10 +2,14 @@
 
 package org.jetbrains.grammarkit.tasks
 
-import org.jetbrains.grammarkit.GrammarKitConstants
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+import org.jetbrains.grammarkit.GrammarKitConstants.GENERATE_LEXER_TASK_NAME
 import org.jetbrains.grammarkit.GrammarKitPluginBase
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class GenerateLexerTaskSpec : GrammarKitPluginBase() {
 
@@ -14,14 +18,13 @@ class GenerateLexerTaskSpec : GrammarKitPluginBase() {
         buildFile.groovy("""
             generateLexer {
                 sourceFile = project.file("${getResourceFile("generateLexer/Example.flex")}")
-                targetDir = "gen/org/jetbrains/grammarkit/lexer/"
-                targetClass = "ExampleLexer"
+                targetOutputDir = project.layout.projectDirectory.dir("gen/org/jetbrains/grammarkit/lexer/")
             }
         """)
 
-        val result = build(GrammarKitConstants.GENERATE_LEXER_TASK_NAME)
+        val result = build(GENERATE_LEXER_TASK_NAME)
 
-        assertTrue(result.output.contains("> Task :${GrammarKitConstants.GENERATE_LEXER_TASK_NAME}"))
+        assertTrue(result.output.contains("> Task :$GENERATE_LEXER_TASK_NAME"))
         assertTrue(adjustWindowsPath(result.output).contains("Writing code to \"${adjustWindowsPath(dir.canonicalPath)}/gen/org/jetbrains/grammarkit/lexer/GeneratedLexer.java\""))
     }
 
@@ -30,14 +33,51 @@ class GenerateLexerTaskSpec : GrammarKitPluginBase() {
         buildFile.groovy("""
             generateLexer {
                 sourceFile = project.file("${getResourceFile("generateLexer/Example.flex")}")
-                targetDir = "gen/org/jetbrains/grammarkit/lexer/"
-                targetClass = "ExampleLexer"
+                targetOutputDir = project.layout.projectDirectory.dir("gen/org/jetbrains/grammarkit/lexer/")
             }
         """)
 
-        build(GrammarKitConstants.GENERATE_LEXER_TASK_NAME, "--configuration-cache")
-        val result = build(GrammarKitConstants.GENERATE_LEXER_TASK_NAME, "--configuration-cache")
+        val firstRun = build(GENERATE_LEXER_TASK_NAME, "--configuration-cache")
+        assertEquals(SUCCESS, firstRun.task(":$GENERATE_LEXER_TASK_NAME")?.outcome)
+        val secondRun = build(GENERATE_LEXER_TASK_NAME, "--configuration-cache")
 
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertTrue(secondRun.output.contains("Reusing configuration cache."))
+        assertEquals(UP_TO_DATE, secondRun.task(":$GENERATE_LEXER_TASK_NAME")?.outcome)
+    }
+    
+    @Test
+    fun `supports build cache`() {
+        buildFile.groovy("""
+            generateLexer {
+                sourceFile = project.file("${getResourceFile("generateLexer/Example.flex")}")
+                targetOutputDir = project.layout.buildDirectory.dir("gen/org/jetbrains/grammarkit/lexer/")
+            }
+        """)
+
+        val firstRun = build(GENERATE_LEXER_TASK_NAME, "--build-cache")
+        assertEquals(SUCCESS, firstRun.task(":$GENERATE_LEXER_TASK_NAME")?.outcome)
+
+        build("clean", "--build-cache")
+        
+        val secondRun = build(GENERATE_LEXER_TASK_NAME, "--build-cache")
+        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":$GENERATE_LEXER_TASK_NAME")?.outcome)
+    }
+
+    @Test
+    fun `support java srcDir`() {
+        buildFile.groovy("""
+            generateLexer {
+                sourceFile = project.file("${getResourceFile("generateLexer/Example.flex")}")
+                targetOutputDir = project.layout.projectDirectory.dir("gen/org/jetbrains/grammarkit/lexer/")
+            }
+            sourceSets.main {
+              java.srcDir(tasks.generateLexer)
+            }
+        """)
+
+        val cantCompileJava = true
+        val result = build(fail = cantCompileJava, "compileJava")
+        
+        assertEquals(SUCCESS, result.task(":$GENERATE_LEXER_TASK_NAME")?.outcome)
     }
 }

--- a/src/test/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/grammarkit/tasks/GenerateParserTaskSpec.kt
@@ -2,10 +2,14 @@
 
 package org.jetbrains.grammarkit.tasks
 
-import org.jetbrains.grammarkit.GrammarKitConstants
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import org.jetbrains.grammarkit.GrammarKitConstants.GENERATE_PARSER_TASK_NAME
 import org.jetbrains.grammarkit.GrammarKitPluginBase
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class GenerateParserTaskSpec : GrammarKitPluginBase() {
 
@@ -14,15 +18,15 @@ class GenerateParserTaskSpec : GrammarKitPluginBase() {
         buildFile.groovy("""
             generateParser {
                 sourceFile = project.file("${getResourceFile("generateParser/Example.bnf")}")
-                targetRoot = "gen"
+                targetRootOutputDir = project.layout.projectDirectory.dir("gen")
                 pathToParser = "/org/jetbrains/grammarkit/IgnoreParser.java"
                 pathToPsiRoot = "/org/jetbrains/grammarkit/psi"
             }
         """)
 
-        val result = build(GrammarKitConstants.GENERATE_PARSER_TASK_NAME)
+        val result = build(GENERATE_PARSER_TASK_NAME)
 
-        assertTrue(result.output.contains("> Task :${GrammarKitConstants.GENERATE_PARSER_TASK_NAME}"))
+        assertTrue(result.output.contains("> Task :$GENERATE_PARSER_TASK_NAME"))
         assertTrue(adjustWindowsPath(result.output).contains("Example.bnf parser generated to ${adjustWindowsPath(dir.canonicalPath)}/gen"))
     }
 
@@ -31,15 +35,57 @@ class GenerateParserTaskSpec : GrammarKitPluginBase() {
         buildFile.groovy("""
             generateParser {
                 sourceFile = project.file("${getResourceFile("generateParser/Example.bnf")}")
-                targetRoot = "gen"
+                targetRootOutputDir = project.layout.projectDirectory.dir("gen")
                 pathToParser = "/org/jetbrains/grammarkit/IgnoreParser.java"
                 pathToPsiRoot = "/org/jetbrains/grammarkit/psi"
             }
         """)
 
-        build(GrammarKitConstants.GENERATE_PARSER_TASK_NAME, "--configuration-cache")
-        val result = build(GrammarKitConstants.GENERATE_PARSER_TASK_NAME, "--configuration-cache")
+        val firstRun = build(GENERATE_PARSER_TASK_NAME, "--configuration-cache")
+        assertEquals(SUCCESS, firstRun.task(":$GENERATE_PARSER_TASK_NAME")?.outcome)
 
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        val secondRun = build(GENERATE_PARSER_TASK_NAME, "--configuration-cache")
+        assertTrue(secondRun.output.contains("Reusing configuration cache."))
+        assertEquals(UP_TO_DATE, secondRun.task(":$GENERATE_PARSER_TASK_NAME")?.outcome)
+    }
+    
+    @Test
+    fun `supports build cache`() {
+        buildFile.groovy("""
+            generateParser {
+                sourceFile = project.file("${getResourceFile("generateParser/Example.bnf")}")
+                targetRootOutputDir = project.layout.buildDirectory.dir("gen")
+                pathToParser = "/org/jetbrains/grammarkit/IgnoreParser.java"
+                pathToPsiRoot = "/org/jetbrains/grammarkit/psi"
+            }
+        """)
+
+        val firstRun = build(GENERATE_PARSER_TASK_NAME, "--build-cache")
+        assertEquals(SUCCESS, firstRun.task(":$GENERATE_PARSER_TASK_NAME")?.outcome)
+
+        build("clean", "--build-cache")
+
+        val secondRun = build(GENERATE_PARSER_TASK_NAME, "--build-cache")
+        assertEquals(FROM_CACHE, secondRun.task(":$GENERATE_PARSER_TASK_NAME")?.outcome)
+    }
+
+    @Test
+    fun `support java srcDir`() {
+        buildFile.groovy("""
+            generateParser {
+                sourceFile = project.file("${getResourceFile("generateParser/Example.bnf")}")
+                targetRootOutputDir = project.layout.projectDirectory.dir("gen")
+                pathToParser = "/org/jetbrains/grammarkit/IgnoreParser.java"
+                pathToPsiRoot = "/org/jetbrains/grammarkit/psi"
+            }
+            sourceSets.main {
+              java.srcDir(tasks.generateParser)
+            }
+        """)
+
+        val cantCompileJava = true
+        val result = build(fail = cantCompileJava, "compileJava")
+        
+        assertEquals(SUCCESS, result.task(":$GENERATE_PARSER_TASK_NAME")?.outcome)
     }
 }


### PR DESCRIPTION
…e kotlin jvm plugin

# Pull Request Details
Do you want to split this PR into smaller ones?
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adopt Gradle best practices:
- Support build cache. Currently, the parser task is not cacheable due to overlapping outputs. Although all files are generated in `targetOutputDir`, there are multiple `@OutputFiles`.
- Support java srcDir task dependency. This is not needed anymore: 
```kotlin
tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
  dependsOn(tasks.generateParser, tasks.generateLexer)
}
```
- Remove kotlin-jvm plugin. This plugin is added by the kotlin-dsl with the supported version. You should not overwrite the version.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
`./gradlew clean build`/CI
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
