### PR TITLE
Fix builds on forked pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
     name: Gradle ${{ matrix.gradleVersion }} @ ${{ matrix.os }}
     needs: gradleValidation
     runs-on: ${{ matrix.os }}
-    permissions:
-      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -84,14 +82,6 @@ jobs:
       - name: Run Tests
         run: ./gradlew check -PtestGradleVersion="${{ matrix.gradleVersion }}" ${{ runner.os == 'Windows' && '-PtestGradleUserHome="C:\\testGradleHome"' || '' }}
 
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: ${{ always() }}
-        with:
-          name: "Unit Tests Report: Gradle ${{ matrix.gradleVersion }} @ ${{ matrix.os }}"
-          path: "**/build/test-results/*/TEST-*.xml"
-          reporter: java-junit
-
       - name: Collect Test Results
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -100,6 +90,7 @@ jobs:
           path: |
             ${{ github.workspace }}/build/reports/tests/test/
             ${{ github.workspace }}/build/reports/configuration-cache
+            ${{ github.workspace }}/build/test-results
 
   build:
     name: Build

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,25 @@
+name: Test Report
+run-name: >
+  Test Report for ${{ github.event.workflow.name }}
+  #${{ github.event.workflow_run.run_number }}:
+  ${{ github.event.workflow_run.display_title }}
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+
+jobs:
+  report:
+    name: Test Report
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        with:
+          artifact: /test-results-([^-]*)-(.*)/
+          name: "Unit Tests Report: Gradle $1 @ $2"
+          path: "test-results/*/TEST-*.xml"
+          reporter: java-junit
+          fail-on-empty: false


### PR DESCRIPTION
# Pull Request Details

## Description

The action `dorny/test-reporter@v1` requires write permissions, which are not available for pull requests from forked repositories.

This PR applies the same fix as in JetBrains/gradle-changelog-plugin#170. Due to dorny/test-reporter#343, this fix alone didn't work, so I also applied a workaround with commit b8ffd1631afcfead474d49c9985423c9634a698c.

Note that I also just created a pull request at dorny/test-reporter#436 which fixes the second issue according to my tests. Depending on whether and how fast the PR gets accepted, the workaround might become obsolete soon.

## Related Issue

* #179

## Motivation and Context

Fix the build of #179.

## How Has This Been Tested

I created a pull request on my fork with a failing unit test.

https://github.com/JojOatXGME/gradle-grammar-kit-plugin/pull/1

This demonstrates that the test reports are still working. However, this test does not demonstrate that the bug is actually fixed, since my pull request is not coming from a different fork. However, it worked for the *gradle-changelog-plugin*.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
